### PR TITLE
install_linux.sh: extract linuxdeployqt before invoking it

### DIFF
--- a/install_linux.sh
+++ b/install_linux.sh
@@ -41,9 +41,14 @@ else
   chmod 0755 linuxdeployqt-6-x86_64.AppImage
 fi
 
+# if we extract linuxdeployqt instead of "running the AppImage", it works on
+# more machines (in particular it will work even on those Docker boxes where
+# FUSE is disabled)
+./linuxdeployqt-6-x86_64.AppImage --appimage-extract
+
 # '-unsupported-allow-new-glibc' enables running this script on Ubuntu 18
 # ^^ BE ADVISED ^^ The above means your image ONLY RUNS ON 18 AND UP.
-./linuxdeployqt-6-x86_64.AppImage \
+squashfs-root/usr/bin/linuxdeployqt \
     AppImage_staging/usr/share/applications/app.desktop \
     -extra-plugins=imageformats,platformthemes/libqgtk3.so,platforms/libqxcb.so,xcbglintegrations/libqxcb-glx-integration.so,platforminputcontexts/libibusplatforminputcontextplugin.so \
     -qmldir=src/ \

--- a/tools/ci/provision.sh
+++ b/tools/ci/provision.sh
@@ -33,8 +33,11 @@ sudo apt-get --assume-yes install \
   libgl1-mesa-glx \
   libglib2.0-0 \
   libglu1-mesa-dev \
+  libgtk-3-0 \
   libharfbuzz0b \
   libicu60 \
+  libjpeg8 \
+  libtiff5 \
   libxcb-icccm4 \
   libxcb-image0 \
   libxcb-keysyms1 \
@@ -49,5 +52,3 @@ sudo apt-get --assume-yes install \
   python3 \
   wget \
   xvfb
-
-sudo modprobe fuse # fuse is needed for our AppImage creation script


### PR DESCRIPTION
this allows things to work in more Docker images than before.
(in particular, things will now work on the ubuntu:18.04 image
used by a Bitbucket pipeline)