### PR TITLE
add visual QML debug helper. saves repeat insert/delete of this item.

### DIFF
--- a/src/lib/libresources.qrc
+++ b/src/lib/libresources.qrc
@@ -2,6 +2,7 @@
   <qresource prefix="">
     <!-- PLEASE OBEY ALPHABETICAL ORDER -->
     <file>qml/homepage.qml</file>
+    <file>qml/DebugRectangle.qml</file>
     <file>qml/ImageSvgHelper.qml</file>
     <file>qml/LogTags.qml</file>
     <file>qml/qmldir</file>

--- a/src/lib/qml/DebugRectangle.qml
+++ b/src/lib/qml/DebugRectangle.qml
@@ -1,0 +1,13 @@
+import QtQuick 2.12
+
+Rectangle {
+  property var toFill: parent
+  property color customColor: 'yellow' // instantiation site "can" (optionally) override
+  property int customThickness: 1 // instantiation site "can" (optionally) override
+
+  anchors.fill: toFill
+  z: 200
+  color: 'transparent'
+  border.color: customColor
+  border.width: customThickness
+}

--- a/src/lib/qml/homepage.qml
+++ b/src/lib/qml/homepage.qml
@@ -132,6 +132,8 @@ ApplicationWindow {
       }
       Label {
         text: 'SPACEBAR (on logo): rotates logo'
+        DebugRectangle {
+        }
       }
     }
   }


### PR DESCRIPTION
I often find myself typing out this Rectangle code on the fly,
only to delete it soon after. Encapsulating this simple bit of
code will let me reuse it much more quickly, even going so far
as to leave instances of DebugRectangle in the code, but
simply toggle:

    visible: false  // only set to true locally; never 'officially'