### PR TITLE
Transform this project into a cookiecutter template on every commit

### DIFF
--- a/.github/workflows/cookiecutter.yml
+++ b/.github/workflows/cookiecutter.yml
@@ -1,0 +1,30 @@
+#
+# Copyright (c) 2020, 219 Design, LLC
+# See LICENSE.txt
+#
+# https://www.219design.com
+# Software | Electrical | Mechanical | Product Design
+#
+name: Cookiecutter
+on:
+  push:
+    branches-ignore:
+      - cookiecutter
+jobs:
+  cookiecutter:
+    runs-on: ubuntu-18.04
+    steps:
+    - uses: actions/checkout@v1
+    # Remove apt repos that are known to break from time to time
+    # See https://github.com/actions/virtual-environments/issues/323
+    - name: Remove broken apt repos
+      run: |
+        for apt_file in `grep -lr microsoft /etc/apt/sources.list.d/`; do sudo rm $apt_file; done
+    - if: runner.os == 'Linux'
+      # Fix (another kind) of azure ubuntu apt repo issue. (Unable to connect to azure.archive.ubuntu.com)
+      run: sed -e 's/azure.archive.ubuntu.com/us.archive.ubuntu.com/g' -e t -e d /etc/apt/sources.list | sudo tee /etc/apt/sources.list.d/nonazure.list
+    - name: cutterize and test
+      env:
+        COOKIECUTTER_PUSH_USER: ${{ secrets.COOKIECUTTER_PUSH_USER }}
+        COOKIECUTTER_PUSH_TOKEN: ${{ secrets.COOKIECUTTER_PUSH_TOKEN }}
+      run: ./cookiecutter/cutterize_and_test.sh

--- a/cookiecutter/cookiecutter.json
+++ b/cookiecutter/cookiecutter.json
@@ -1,0 +1,12 @@
+{
+  "project_name": "QT/QML Project Template With CI",
+  "folder_name": "{{ cookiecutter.project_name.lower().replace('/', '_').replace(' ', '_') }}",
+  "cpp_namespace": "com::two_one_nine::my_project",
+  "who_am_I": "219 Design, LLC",
+  "website": "219design.com",
+  "email": "getstarted@219design.com",
+  "year": "2020",
+  "_copy_without_render": [
+    "*third_party"
+  ]
+}

--- a/cookiecutter/cookiecutterize.sh
+++ b/cookiecutter/cookiecutterize.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+# This script turns the 219 Design starter Qt project into a cookiecutter template
+
+set -Eeuxo pipefail # https://vaneyckt.io/posts/safer_bash_scripts_with_set_euxo_pipefail/
+
+CUR_GIT_ROOT=$(git rev-parse --show-toplevel)
+cd $CUR_GIT_ROOT
+
+# Escapes literal {{ in the code. See https://jinja.palletsprojects.com/en/2.11.x/templates/#escaping
+grep -l -R --binary-files=without-match "{{" src .github | xargs sed -i "s/{{/{{ '{{' }}/g"
+
+# Modifies the copyright
+git mv LICENSE.txt 219Design.LICENSE.txt
+grep -l -E -R --binary-files=without-match 'Copyright \(c\) [0-9]{4}, 219 Design, LLC' src |\
+    xargs sed -Ei -e "s/[0-9]{4}, 219 Design, LLC/{{ cookiecutter.year }}, {{ cookiecutter.who_am_I }} ({{ cookiecutter.email }})/g"\
+    -e "s#https://www.219design.com#{{ cookiecutter.website }}#g"
+find src/ -type f | xargs sed -i "/Software | Electrical | Mechanical | Product Design/d"
+
+## Sets a custom namespace for the project
+## Unfortunately sed doesn't play nicely with multi-line matches. Perl to the rescue
+FILE_LIST=$(grep -l -E -R --binary-files=without-match '^namespace project' src)
+echo "$FILE_LIST" | xargs -I ';;;' perl -0777 -i -pe "s/namespace project\n\{/{% set nslist = cookiecutter.cpp_namespace.split('::') %}\n{% for ns in nslist %}\nnamespace {{ ns }}\n{\n{% endfor %}/g" ';;;'
+echo "$FILE_LIST" | xargs -I ';;;' sed -i "s#^} // namespace project#{% for ns in nslist %}\n} // namespace {{ ns }}\n{% endfor %}#g" ';;;'
+grep -l -R --binary-files=without-match "project::" src | xargs sed -i "s/project::/{{ cookiecutter.cpp_namespace | replace('.', '::') }}::/g"
+
+# Customizes the App.Desktop entry and the Window title
+sed -i -e "s/Name=.*/Name={{ cookiecutter.project_name }}/g"\
+    -e "/Comment=.*/d"\
+    tools/AppImage/app.desktop
+sed -i -e "s/Hello World/Hello {{ cookiecutter.folder_name }}/g" src/lib/qml/*.qml
+
+# Finally, moves the project folder to a cookiecutter namespace
+mkdir "{{ cookiecutter.folder_name }}"
+rm src/lib/qml/images qmake.conf clang-format
+git add "{{ cookiecutter.folder_name }}"
+shopt -s dotglob nullglob extglob # so hidden files move, too. https://unix.stackexchange.com/q/6393/11592
+git mv -k !(.gitmodules|..|.) "{{ cookiecutter.folder_name }}"/
+git mv -k "{{ cookiecutter.folder_name }}"/cookiecutter/* .
+git mv -k init_repo.sh "{{ cookiecutter.folder_name }}"/
+rm -r "{{ cookiecutter.folder_name }}"/cookiecutter

--- a/cookiecutter/cutterize_and_test.sh
+++ b/cookiecutter/cutterize_and_test.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+
+#
+# Copyright (c) 2020, 219 Design, LLC
+# See LICENSE.txt
+#
+# https://www.219design.com
+# Software | Electrical | Mechanical | Product Design
+#
+
+set -Eeuxo pipefail # https://vaneyckt.io/posts/safer_bash_scripts_with_set_euxo_pipefail/
+
+git config --global user.name "Workflow Worker"
+git config --global user.email "nobody@219design.com"
+
+# Cookiecutterize the project and stage the repo for push to branch
+cd $GITHUB_WORKSPACE
+git checkout -b qt_cookiecutter
+./cookiecutter/cookiecutterize.sh
+git commit -am "cookiecutterized invocation($INVOCATION_ID)"
+
+# Exercise cookiecutter and associated tests
+cd $HOME
+pip3 install -U pip setuptools
+pip3 install cookiecutter
+pip3 show cookiecutter
+sudo apt install tree
+$HOME/.local/bin/cookiecutter --no-input --verbose $GITHUB_WORKSPACE/
+cd $HOME/qt_qml_project_template_with_ci
+./init_repo.sh
+./run_all_tests.sh || exit 1
+
+if [ "$GITHUB_REF" != "refs/heads/master" ]; then
+    echo "NOT BUILT ON MASTER. Not pushing cookiecutter branch."
+    echo "SUCCESS"
+    exit 0
+fi
+
+# Tests were successful, continue pushing the cutterized branch upstream
+remote_repo="https://${COOKIECUTTER_PUSH_USER}:${COOKIECUTTER_PUSH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
+cd $GITHUB_WORKSPACE
+git push "${remote_repo}" HEAD:cookiecutter --force

--- a/cookiecutter/init_repo.sh
+++ b/cookiecutter/init_repo.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+# A cookiecutter project will not have submodules set up. This initializes a
+# cookiecutter project, removing all assumptions of an existing git repo.
+
+set -Eeuxo pipefail # https://vaneyckt.io/posts/safer_bash_scripts_with_set_euxo_pipefail/
+
+rm -r build_qt_binaries
+
+ln -s src/libstyles/imports/libstyles/images src/lib/qml/images
+ln -s .qmake.conf qmake.conf
+ln -s .clang-format clang-format
+
+git init
+git add .
+git submodule add https://github.com/219-design/build_qt_binaries.git
+git submodule update --init --recursive
+git commit -m "init"
+
+./tools/formatters/enforce_clang_format.sh

--- a/cookiecutter/{{ cookiecutter.folder_name }}/init_repo.sh
+++ b/cookiecutter/{{ cookiecutter.folder_name }}/init_repo.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+# A cookiecutter project will not have submodules set up. This initializes a
+# cookiecutter project, removing all assumptions of an existing git repo.
+
+set -Eeuxo pipefail # https://vaneyckt.io/posts/safer_bash_scripts_with_set_euxo_pipefail/
+
+rm -r build_qt_binaries .gitmodules
+
+git init
+git submodule add https://github.com/219-design/build_qt_binaries.git
+git submodule update --init --recursive
+
+./tools/formatters/enforce_clang_format.sh

--- a/tools/gui_test/check_gui_test_log.py
+++ b/tools/gui_test/check_gui_test_log.py
@@ -11,7 +11,7 @@
 import sys
 
 MUST_HAVE = [
-    "main.qml(20): ApplicationWindow onCompleted",
+    "ApplicationWindow onCompleted",
 ]
 
 MUST_NOT = [


### PR DESCRIPTION
Whenever a push happens to any branch, Github Workflows will run a script to
translate this project into a cookiecutter-friendly template. See
https://github.com/cookiecutter/cookiecutter for more on why this is awesome.

When you want to start a new Qt project, run:

```
cookiecutter gh:219-design/qt-qml-project-template-with-ci --checkout origin/cookiecutter
```

It'll then ask a handful of questions to personalize the project. For example:

```
$ cookiecutter gh:219-design/qt-qml-project-template-with-ci --checkout origin/cookiecutter
project_name [QT/QML Project Template With CI]: My Project
folder_name [my_project]: ⏎ 
cpp_namespace [com::two_one_nine::my_project]: com::my::project
who_am_I [219 Design, LLC]: Developer
website [219design.com]: developer.com
email [getstarted@219design.com]: dev@developer.com
year [2020]: ⏎
$ cd my_project
$ ./init_repo.sh
...
$ ./build_app.sh
```
You'll need to run `./init_repo.sh` to initialize the repository and set up submodules.

Note: For all branches, this "cookiecutterize" workflow runs all CI tests to
ensure that the template is still valid after it's been created from the same
commit. When a push happens on the `master` branch, the workflow will also
force-push a fresh cookiecutter template to the `cookiecutter` branch.
