### PR TITLE
build for macOS desktop.

### DIFF
--- a/build_app.sh
+++ b/build_app.sh
@@ -33,3 +33,9 @@ popd >& /dev/null
 if [[ -z ${MYAPP_TEMPLATE_SKIP_ANDROID-} ]]; then
   tools/ci/build_android_app.sh
 fi
+
+if [[ "$OSTYPE" == "darwin"* ]]; then
+  pushd build/src/app >& /dev/null
+    macdeployqt app.app -libpath=$PWD -qmldir=../../../src/
+  popd >& /dev/null
+fi

--- a/compiler_flags.pri
+++ b/compiler_flags.pri
@@ -49,7 +49,7 @@ linux:!android {
          "
 }
 
-unix:{
+linux:{
     # some inspired by: https://kristerw.blogspot.com/2017/09/useful-gcc-warning-options-not-enabled.html
     # others inspired by: https://stackoverflow.com/questions/5088460/flags-to-enable-thorough-and-verbose-g-warnings
     QMAKE_CXXFLAGS += "\

--- a/path_to_qmake.bash
+++ b/path_to_qmake.bash
@@ -10,4 +10,8 @@ CUR_GIT_ROOT=$(git rev-parse --show-toplevel)
 
 DL_FOLDER=$CUR_GIT_ROOT/dl_third_party
 
-export PATH="$DL_FOLDER/Qt_desktop/5.15.0/gcc_64/bin/:$PATH"
+if [[ "$OSTYPE" == "darwin"* ]]; then
+  export PATH="$DL_FOLDER/Qt_desktop/5.15.0/clang_64/bin/:$PATH"
+else
+  export PATH="$DL_FOLDER/Qt_desktop/5.15.0/gcc_64/bin/:$PATH"
+fi

--- a/tools/update_version_strings.sh
+++ b/tools/update_version_strings.sh
@@ -21,6 +21,12 @@ LAST_KNOWN_HASH=`git rev-parse --verify --short=10 HEAD`
 NEW_DATELINE="constexpr char BUILD_ON_DATE[] = \"${BUILD_DATE}\";"
 NEW_HASHLINE="constexpr char GIT_HASH_WHEN_BUILT[] = \"${LAST_KNOWN_HASH}\";"
 
-# find matching lines and replace WHOLE line with new strings
-sed "/BUILD_ON_DATE/c ${NEW_DATELINE}" "$STRINGSFILE" > "$GENFILE" # 1. create genfile
-sed -i "/GIT_HASH_WHEN_BUILT/c ${NEW_HASHLINE}" "$GENFILE"         # 2. then operate in-place on genfile
+if [[ "$OSTYPE" == "darwin"* ]]; then
+  # find matching lines and replace WHOLE line with new strings
+  gsed "/BUILD_ON_DATE/c ${NEW_DATELINE}" "$STRINGSFILE" > "$GENFILE" # 1. create genfile
+  gsed -i "/GIT_HASH_WHEN_BUILT/c ${NEW_HASHLINE}" "$GENFILE"         # 2. then operate in-place on genfile
+else
+  # find matching lines and replace WHOLE line with new strings
+  sed "/BUILD_ON_DATE/c ${NEW_DATELINE}" "$STRINGSFILE" > "$GENFILE" # 1. create genfile
+  sed -i "/GIT_HASH_WHEN_BUILT/c ${NEW_HASHLINE}" "$GENFILE"         # 2. then operate in-place on genfile
+fi


### PR DESCRIPTION
until we enable Mac OS continuous integration actions, this is
hardly more robust than commenting. it works on my machine ;)

YMMV (for now). I installed a few things via homebrew, most
notably gsed.

the following yields a working app bundle for me locally:

    tools/ci/get_qt_libs.sh
    export MYAPP_TEMPLATE_SKIP_ANDROID=1
    ./build_app.sh
    open build/src/app/app.app