### PR TITLE
build for iOS iPhone app

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@ build
 AppImage_staging
 linuxdeployqt-6-x86_64.AppImage
 gui_test.log
+
+# mac:
+**/.DS_Store

--- a/README.md
+++ b/README.md
@@ -79,6 +79,11 @@ After that, please proceed to "How to build" (below) before continuing further:
 5. Assuming step (4) was successful, you can launch the app at
    `./build/src/app/app`
 
+   For the iOS version of the app, one of the outputs of `build_app.sh` will be
+   the xcodeproj. Open the xcodeproj in Xcode and from there you can choose a
+   simulator or a device as the "Destination" and then choose "Run" (or command
+   R). The xcodeproj is created at: `build/for_ios/src/app/app.xcodeproj`
+
    If the app fails with a message such as `qt.qpa.plugin: Could not
    load the Qt platform plugin "xcb" in
    "/home/daniel/Qt/5.15.0/gcc_64/plugins" even though it was found.`,

--- a/build_app.sh
+++ b/build_app.sh
@@ -39,4 +39,6 @@ if [[ "$OSTYPE" == "darwin"* ]]; then
     macdeployqt app.app -libpath=$PWD -qmldir=../../../src/
     macdeployqt lib_tests.app -libpath=$PWD -qmldir=../../../src/
   popd >& /dev/null
+
+  ./build_ios_app.sh
 fi

--- a/build_ios_app.sh
+++ b/build_ios_app.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+set -Eeuxo pipefail # https://vaneyckt.io/posts/safer_bash_scripts_with_set_euxo_pipefail/
+
+pushd .
+trap "popd" EXIT HUP INT QUIT TERM
+
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+cd $DIR  # enter this script's directory. (in case called from root of repository)
+
+$DIR/tools/ci/version.sh
+
+source $DIR/path_to_ios_qmake.bash
+
+mkdir -p build/for_ios
+
+pushd build/for_ios >& /dev/null
+
+  qmake "$DIR"
+  make
+
+popd >& /dev/null

--- a/cookiecutter/init_repo.sh
+++ b/cookiecutter/init_repo.sh
@@ -24,6 +24,7 @@ git add -f dl_third_party/Qt_desktop/5.15.0/gcc_64/extrabin/qmlfmt
 git add -f dl_third_party/Qt_desktop/5.15.0/gcc_64/lib/libicudata.so.56
 git add -f dl_third_party/Qt_desktop/5.15.0/gcc_64/lib/libicui18n.so.56
 git add -f dl_third_party/Qt_desktop/5.15.0/gcc_64/lib/libicuuc.so.56
+git add -f dl_third_party/Qt_desktop/5.15.0/ios/mkspecs/qconfig.pri
 git add -f dl_third_party/android_kits/commandlinetools-linux-6200805_latest.zip.sha256
 
 git commit -m "init"

--- a/dl_third_party/Qt_desktop/5.15.0/ios/mkspecs/qconfig.pri
+++ b/dl_third_party/Qt_desktop/5.15.0/ios/mkspecs/qconfig.pri
@@ -1,0 +1,27 @@
+host_build {
+    QT_ARCH = x86_64
+    QT_BUILDABI = x86_64-little_endian-lp64
+    QT_TARGET_ARCH = arm64
+    QT_TARGET_BUILDABI = arm64-little_endian-lp64
+} else {
+    QT_ARCH = arm64
+    QT_BUILDABI = arm64-little_endian-lp64
+}
+QT.global.enabled_features = cross_compile appstore-compliant debug_and_release build_all c++11 c++14 c++17 c++1z c99 c11 thread future concurrent signaling_nan simulator_and_device static
+QT.global.disabled_features = shared shared framework rpath c++2a pkg-config force_asserts separate_debug_info
+CONFIG += cross_compile debug static
+QT_CONFIG += debug_and_release release debug build_all c++11 c++14 c++17 c++1z concurrent no-pkg-config reduce_exports release_tools simulator_and_device static stl
+QT_VERSION = 5.15.0
+QT_MAJOR_VERSION = 5
+QT_MINOR_VERSION = 15
+QT_PATCH_VERSION = 0
+QT_GCC_MAJOR_VERSION = 4
+QT_GCC_MINOR_VERSION = 2
+QT_GCC_PATCH_VERSION = 1
+QT_MAC_SDK_VERSION = 13.2
+QT_APPLE_CLANG_MAJOR_VERSION = 11
+QT_APPLE_CLANG_MINOR_VERSION = 0
+QT_APPLE_CLANG_PATCH_VERSION = 0
+QT_EDITION = OpenSource
+QT_LICHECK = 
+QT_RELEASE_DATE = 2020-04-04

--- a/path_to_ios_qmake.bash
+++ b/path_to_ios_qmake.bash
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+if [ "${BASH_SOURCE[0]}" -ef "$0" ]
+then
+    echo "Hey, you should source this script, not execute it!"
+    exit 1
+fi
+
+CUR_GIT_ROOT=$(git rev-parse --show-toplevel)
+
+DL_FOLDER=$CUR_GIT_ROOT/dl_third_party
+
+export PATH="$DL_FOLDER/Qt_desktop/5.15.0/ios/bin/:$PATH"

--- a/src/app/imports.qml
+++ b/src/app/imports.qml
@@ -1,0 +1,24 @@
+/*
+Declaration of QML Imports required by the app.
+
+This is necessary because of the way qmlimportscanner works.  If these imports
+are not declared, qmake will not recognize them, and QtQuick will not be
+packaged with statically built apps (i.e. iOS) and imported at runtime.
+
+https://forum.qt.io/topic/56748/what-s-the-equivalent-of-macdeployqt-s-qmldir-option-for-ios-builds/3
+
+Keep this up to date by periodically running:
+grep -rIw import src/ | awk -F: '{print $2}' | sort | uniq
+
+*/
+import QtGraphicalEffects 1.12
+import QtQuick 2.1
+import QtQuick 2.12
+import QtQuick.Controls 2.12
+import QtQuick.Controls.Universal 2.2
+import QtQuick.Dialogs 1.3
+import QtQuick.Layouts 1.14
+import QtQuick.Window 2.1
+
+QtObject {
+}

--- a/src/assert/util-assert.h
+++ b/src/assert/util-assert.h
@@ -23,6 +23,7 @@
 
 #if defined( __APPLE__ )
 #    include <CoreFoundation/CoreFoundation.h>
+#    include <TargetConditionals.h>
 #    define _putenv putenv
 #endif // defined(__APPLE__)
 
@@ -89,7 +90,7 @@ static inline void OptionToContinue(
     (void) line;
     (void) funcname;
 
-#elif defined( __APPLE__ )
+#elif defined( __APPLE__ ) && !( TARGET_OS_IPHONE )
 
     fprintf( stderr, "%s:\n", title );
     fprintf( stderr, "%s\n", funcname );
@@ -141,7 +142,7 @@ static inline void OptionToContinue(
         fprintf( stderr, "ignoring opportunity to debug the FAIL (either due to inaction or ESC key)\n" );
     }
 
-#elif defined( __linux__ )
+#elif defined( __unix__ )
 
     fprintf( stderr, "%s:\n", title );
     fprintf( stderr, "%s\n", funcname );

--- a/src/lib/lib.pro
+++ b/src/lib/lib.pro
@@ -3,7 +3,9 @@
 QT += core qml quick svg widgets
 
 TEMPLATE = lib
-CONFIG += shared
+!ios {
+  CONFIG += shared
+}
 
 RESOURCES = libresources.qrc
 

--- a/src/libtests/libtestmain.pro
+++ b/src/libtests/libtestmain.pro
@@ -3,7 +3,9 @@
 QT += core
 
 TEMPLATE = lib
-CONFIG += shared
+!ios {
+  CONFIG += shared
+}
 
 TARGET  = testmain
 

--- a/src/util/util.pro
+++ b/src/util/util.pro
@@ -3,7 +3,9 @@
 QT += core
 
 TEMPLATE = lib
-CONFIG += shared
+!ios {
+  CONFIG += shared
+}
 
 SOURCES += \
     every_so_often.cc \

--- a/third_party/googletest-release-1.8.0/googlemock/googlemock.pro
+++ b/third_party/googletest-release-1.8.0/googlemock/googlemock.pro
@@ -25,7 +25,9 @@ QMAKE_CXXFLAGS += "\
     "
 
 TEMPLATE = lib
-CONFIG += shared
+!ios {
+  CONFIG += shared
+}
 
 SOURCES += \
     src/gmock-all.cc \

--- a/third_party/googletest-release-1.8.0/googletest/googletest.pro
+++ b/third_party/googletest-release-1.8.0/googletest/googletest.pro
@@ -27,7 +27,9 @@ QMAKE_CXXFLAGS += "\
     "
 
 TEMPLATE = lib
-CONFIG += shared
+!ios {
+  CONFIG += shared
+}
 
 SOURCES += \
     src/gtest-all.cc \

--- a/tools/ci/get_qt_libs.sh
+++ b/tools/ci/get_qt_libs.sh
@@ -24,4 +24,22 @@ else
    qtsvg \
    qttools
 
+  if [[ "$OSTYPE" == "darwin"* ]]; then
+    bash -x $CUR_GIT_ROOT/tools/ci/install-qt.sh \
+     --directory $DL_FOLDER/Qt_desktop \
+     --version 5.15.0 \
+     --target ios \
+     qtbase \
+     qtconnectivity \
+     qtdeclarative \
+     qtgraphicaleffects \
+     qtimageformats \
+     qtquickcontrols \
+     qtquickcontrols2 \
+     qtsvg \
+     qttools
+
+    git checkout $CUR_GIT_ROOT/dl_third_party/Qt_desktop/5.15.0/ios/mkspecs/qconfig.pri
+  fi
+
 fi


### PR DESCRIPTION
The changes in this commit represent 100% of what was required to take an existing `qmake`-based Qt/QML application project and produce an iOS app from the existing codebase and project files.

Notable changes:

- use `tools/ci/install-qt.sh` to also install Qt with `--target ios` in addition to (default) desktop framework
- add `src/app/imports.qml` (see comments in file for rationale)
- stop using `CONFIG += shared` during the iOS build. (all libs must be static for iOS)
- in order to build unattended (in C.I. action), ios/mkspecs/qconfig.pri cannot contain `QT_EDITION = Enterprise` (or alternatively we could configure C.I. to supply the license file), to prevent the build from hanging and prompting for a license number