### PR TITLE
enhance the visual QML debug helper: toggle via environment, not code

### DIFF
--- a/src/lib_app/qml/DebugRectangle.qml
+++ b/src/lib_app/qml/DebugRectangle.qml
@@ -1,9 +1,21 @@
 import QtQuick 2.12
+import QtQuick.Controls.Material 2.12
 
 Rectangle {
   property var toFill: parent
   property color customColor: "yellow" // instantiation site "can" (optionally) override
   property int customThickness: 1 // instantiation site "can" (optionally) override
+
+  // This is a bit of a "clever hack" for debugging.
+  // There are a limited number of environment vars passed through to QML.
+  // https://doc.qt.io/qt-5/qtquickcontrols2-environment.html
+  // Here, we hijack the QT_QUICK_CONTROLS_MATERIAL_ACCENT variable as a visibility flag.
+  // In this way, you can insert 'DebugRectangle' items wherever you want in your QML.
+  // When you wish for the DebugRectangle(s) to become visible (in a production binary executable
+  // or under qmlscene), then just do this before launch:
+  // export QT_QUICK_CONTROLS_MATERIAL_ACCENT="#0B610B"
+  readonly property color sentinelColor: "#0B610B"
+  visible: Material.accent == sentinelColor
 
   anchors.fill: toFill
   z: 200

--- a/src/lib_app/qml/main.qml
+++ b/src/lib_app/qml/main.qml
@@ -143,6 +143,9 @@ ApplicationWindow {
         text: "SPACEBAR (on logo): rotates logo"
 
         DebugRectangle {
+          // To make the DebugRectangle show up in the GUI, change your environment:
+          //     export QT_QUICK_CONTROLS_MATERIAL_ACCENT="#0B610B"
+          // (See comments in DebugRectangle.qml for more information.)
         }
       }
 

--- a/src/lib_app/qml/runscene
+++ b/src/lib_app/qml/runscene
@@ -6,6 +6,9 @@ CUR_GIT_ROOT=$(git rev-parse --show-toplevel)
 
 source $CUR_GIT_ROOT/path_to_qmake.bash # path to qmake is also path to qmlscene
 
+# In order to cause our DebugRectangle instances to become visible, uncomment:
+# export QT_QUICK_CONTROLS_MATERIAL_ACCENT="#0B610B"
+
 # In order that all the qml 'import' statements for our supporting libraries can
 # successfully load, you must feed some additional paths to qmlscene like so:
 


### PR DESCRIPTION
DebugRectangle was added in commit 1d945aea58a93cd2a7731a50d55c5c66f1a87e36
as an easy way to quickly add visual borders to QML elements, to aid in
tracking down problems with alignment/sizing/layout.

The current commit further improves the convenience of DebugRectangle.
Now you can leave the DebugRectangle instances embedded in the QML code,
and you don't need to edit 'visible' on anything or rebuild the QRC of
your app in order to toggle visibility of the debug borders.

Now, whether you launch your application or whether you only launch your
QML using qmlscene, the debug borders will show up whenever you:

    export QT_QUICK_CONTROLS_MATERIAL_ACCENT="#0B610B" # our 'magic' sentinel value

Ideally we would invent our own environment variable for this purpose.
However, since we want this to work when using qmlscene, we are reliant
100% on only what is achievable in pure QML/Javascript (no support from
C++ viewModel classes we write). In pure QML, there is no way to read
from an environment variable.  Therefore, we use this "clever hack"
which piggy-backs on an environment variable that is read by the C++
code of the QML internal engine itself. The QML internals (included in
both your app and qmlscene) read the value of QT_QUICK_CONTROLS_MATERIAL_ACCENT
and make it available in QML as `Material.accent`. In this way, we
can test the value of `Material.accent` in pure QML to know whether
the environment variable was set.