### PR TITLE
Fixes for template to run on bitbucket pipelines

### DIFF
--- a/bitbucket-pipelines.yml
+++ b/bitbucket-pipelines.yml
@@ -13,4 +13,6 @@ pipelines:
   default:
     - step:
         script:
+          # TODO - look into why bitbucket chokes on this in more detail 
+          - export MYAPP_TEMPLATE_SKIP_APPIMAGE=1
           - ./run_all_tests.sh

--- a/tools/ci/provision.sh
+++ b/tools/ci/provision.sh
@@ -2,9 +2,8 @@
 
 set -Eeuxo pipefail # https://vaneyckt.io/posts/safer_bash_scripts_with_set_euxo_pipefail/
 
-CUR_GIT_ROOT=$(git rev-parse --show-toplevel)
-
 if [[ "$OSTYPE" == "darwin"* ]]; then
+  CUR_GIT_ROOT=$(git rev-parse --show-toplevel)
   ${CUR_GIT_ROOT}/tools/ci/provision_mac.sh
   exit 0
 fi
@@ -72,6 +71,7 @@ sudo apt-get --assume-yes install \
   zlib1g:i386
 
 ## BEGIN: clang-format from LLVM
+CUR_GIT_ROOT=$(git rev-parse --show-toplevel)
 ${CUR_GIT_ROOT}/tools/ci/get_llvm_clang-format.sh
 ## END: clang-format from LLVM
 

--- a/tools/gui_test/launch_gui_for_display.sh
+++ b/tools/gui_test/launch_gui_for_display.sh
@@ -20,9 +20,10 @@ CUR_GIT_ROOT=$(git rev-parse --show-toplevel)
 cd $CUR_GIT_ROOT
 rm -f gui_test.log # in C.I. there should never be a leftover file. but perhaps locally.
 
-if [[ "$OSTYPE" != "darwin"* ]]; then
-  # -g flag causes app to close when test is done:
-  gdb -batch -return-child-result -ex "set args -g -v" -ex "run" -ex "bt" ${CUR_GIT_ROOT}/build/src/app/app 2>&1 | tee gui_test.log
+if [[ -n ${BITBUCKET_REPO_OWNER-} ]]; then
+  ${CUR_GIT_ROOT}/build/src/app/app -g 2>&1 | tee gui_test.log
+ elif [[ "$OSTYPE" != "darwin"* ]]; then
+   gdb -batch -return-child-result -ex "set args -g -v" -ex "run" -ex "bt" ${CUR_GIT_ROOT}/build/src/app/app 2>&1 | tee gui_test.log
 else
   build/src/app/app.app/Contents/MacOS/app -g 2>&1 | tee gui_test.log
 fi


### PR DESCRIPTION
Currently running this template in Bitbucket Pipelines fails.  There are three outstanding reasons for this:

1. The Bitbucket Docker instance does not come with git installed, which our build script assumes.
2. Creating the AppImage using linuxdeployqt.
3.  For some reason, we cannot use gdb in the Docker image that bitbucket uses.

This PR allows the the template to run successfully in Bitbucket Pipelines by resolving (1), skipping (2) by using an environment variable in the Pipelines YAML, and circumventing (3) by not using gdb when we are using Bitbucket CI.