### PR TITLE
install_linux.sh: run linuxdeployqt on bitbucket, thanks to...

### DIFF
--- a/bitbucket-pipelines.yml
+++ b/bitbucket-pipelines.yml
@@ -13,6 +13,4 @@ pipelines:
   default:
     - step:
         script:
-          # TODO - look into why bitbucket chokes on this in more detail 
-          - export MYAPP_TEMPLATE_SKIP_APPIMAGE=1
           - ./run_all_tests.sh


### PR DESCRIPTION
commit a9fd8a04ad (on the github history) or commit 04b193b6c776 (on the bitbucket history)

we did actually figure out how to successfully run linuxdeployqt
in the bitbucket CI docker setting, so therefore we do not
currently have a need to disable it in bitbucket-pipelines.yml