### PR TITLE
remove -Werror from Android build. this pains me,

### DIFF
--- a/compiler_flags.pri
+++ b/compiler_flags.pri
@@ -56,6 +56,12 @@ linux:!android {
          "
 }
 
+!android {
+    QMAKE_CXXFLAGS += "\
+        -Werror \
+        "
+}
+
 # some inspired by: https://kristerw.blogspot.com/2017/09/useful-gcc-warning-options-not-enabled.html
 # others inspired by: https://stackoverflow.com/questions/5088460/flags-to-enable-thorough-and-verbose-g-warnings
 QMAKE_CXXFLAGS += "\
@@ -64,7 +70,6 @@ QMAKE_CXXFLAGS += "\
      -Wcast-qual \
      -Wconversion \
      -Wdisabled-optimization \
-     -Werror \
      -Werror=switch \
      -Wextra \
      -Wfloat-equal \


### PR DESCRIPTION
but I cannot (in a limited box of time) figure out why the following
appeared (seemingly out of nowhere) to fail our builds:

    qt-qml-project-template-with-ci/third_party/googletest-release-1.8.0/googlemock/include/gmock/gmock-matchers.h:1180:3: error: definition of implicit copy constructor for 'StrEqualityMatcher<std::__ndk1::basic_string<char, std::__ndk1::char_traits<char>, std::__ndk1::allocator<char>>>' is deprecated because it has a user-declared copy assignment operator [-Werror,-Wdeprecated-copy]

we did not change which Android kit commandlinetools zip we download.
we did not change any code. we did not upgrade OS. we did not
upate googletest/googlemock.