### PR TITLE
ci: use Berkeley and FAU mirror(s) in place of download.qt.io

### DIFF
--- a/tools/ci/get_qt_libs.sh
+++ b/tools/ci/get_qt_libs.sh
@@ -11,6 +11,9 @@ CUR_GIT_ROOT=$(git rev-parse --show-toplevel)
 
 DL_FOLDER=$CUR_GIT_ROOT/dl_third_party
 
+QTMIRROR='http://mirrors.ocf.berkeley.edu/qt/'
+QTSIXMIRROR='http://ftp.fau.de/qtproject'
+
 sudo pip3 install aqtinstall  # https://github.com/miurahr/aqtinstall
 
 if [ -d $DL_FOLDER/Qt_desktop/5.15.0/gcc_64/bin ]; then
@@ -19,7 +22,7 @@ else
 
   if [[ -n ${MYAPP_TEMPLATE_QT6-} ]]; then
     # https://github.com/miurahr/aqtinstall/issues/126 "Installing smaller subset of the libraries"
-    python3 -m aqt install --outputdir $DL_FOLDER/Qt_desktop 6.0.0 linux desktop --archives \
+    python3 -m aqt install --base "${QTSIXMIRROR}" --outputdir $DL_FOLDER/Qt_desktop 6.0.0 linux desktop --archives \
      icu \
      qtbase \
      qtconnectivity \
@@ -33,12 +36,12 @@ else
 
     # we still need qt5 in order to execute qmlfmt. (until we can recompile qmlfmt with qt6)
     # https://github.com/miurahr/aqtinstall/issues/126 "Installing smaller subset of the libraries"
-    python3 -m aqt install --outputdir $DL_FOLDER/Qt_desktop 5.15.0 linux desktop --archives \
+    python3 -m aqt install --base "${QTMIRROR}" --outputdir $DL_FOLDER/Qt_desktop 5.15.0 linux desktop --archives \
      icu \
      qtbase
   else
     # https://github.com/miurahr/aqtinstall/issues/126 "Installing smaller subset of the libraries"
-    python3 -m aqt install --outputdir $DL_FOLDER/Qt_desktop 5.15.0 linux desktop --archives \
+    python3 -m aqt install --base "${QTMIRROR}" --outputdir $DL_FOLDER/Qt_desktop 5.15.0 linux desktop --archives \
      icu \
      qtbase \
      qtconnectivity \


### PR DESCRIPTION
due to a significant Qt archives outage on Jan 18, 2021, I learned
of a feature in miurahr/aqtinstall that allows for explicit choice
of a mirror to be used in place of download.qt.io

the outage has since been repaired, but I am committing this
minor change to document that this choice of mirror exists

https://forum.qt.io/topic/122837/download-qt-io-is-down

https://github.com/miurahr/aqtinstall/issues/194