### PR TITLE
(win32) speed up compilation by increasing CPU utilization of nmake

### DIFF
--- a/windows.pri
+++ b/windows.pri
@@ -14,6 +14,7 @@ win32 {
        /EHs \
        /Gy \
        /FC \
+       /MP \
        /W4 \
        /Wall \
        /WX \


### PR DESCRIPTION
on a specific machine and a specific (private) project based off of
this github template, adding this cl.exe/nmake setting increased
CPU usage from 30% to 100% as observed in Task Manager's Performance tab