### PR TITLE
provision script bug fixes

### DIFF
--- a/tools/ci/provision.sh
+++ b/tools/ci/provision.sh
@@ -48,6 +48,7 @@ sudo apt-get --assume-yes install \
   gdb \
   git \
   gnupg \
+  g++-7 \
   libc-bin \
   libdbus-1-3 \
   libfontconfig1 \

--- a/tools/ci/provision_win.sh
+++ b/tools/ci/provision_win.sh
@@ -14,7 +14,7 @@ pip3 install aqtinstall  # https://github.com/miurahr/aqtinstall
 # Refer to: https://github.com/miurahr/aqtinstall#usage
 
 # https://github.com/miurahr/aqtinstall/issues/126 "Installing smaller subset of the libraries"
-python -m aqt install --outputdir $DL_FOLDER/Qt_desktop 5.15.0 windows desktop win64_msvc2019_64 --archives \
+python -m aqt install-qt windows desktop 5.15.0 win64_msvc2019_64 --outputdir $DL_FOLDER/Qt_desktop --archives \
         icu \
         qtbase \
         qtconnectivity \


### PR DESCRIPTION
- provision.sh is missing the g++-7 package install which causes build_app.sh to fail
- provision_win.sh doesn't specify an aqt version(we should consider locking it down) and the current version depreciated install in favor of install-qt which has a different param order. As a result the script fails.