### PR TITLE
Windows Installation Fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,6 @@ aqtinstall.log
 
 # mac:
 **/.DS_Store
+
+# Qt Creator User File
+*.user

--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ After that, please proceed to "How to build" (below) before continuing further:
 4. In a terminal, run `build_app.sh`
 
 5. Assuming step (4) was successful, you can launch the app at
-   `./build/src/app/app` (or on Windows: `./build/windeployfolder/app.exe`)
+   `./build/src/app/app` (or on Windows: `start build/windeployfolder/app.exe`)
 
    For the iOS version of the app, one of the outputs of `build_app.sh` will be
    the xcodeproj. Open the xcodeproj in Xcode and from there you can choose a

--- a/tools/ci/provision_win.sh
+++ b/tools/ci/provision_win.sh
@@ -5,8 +5,9 @@ set -Eeuxo pipefail # https://vaneyckt.io/posts/safer_bash_scripts_with_set_euxo
 CUR_GIT_ROOT=$(git rev-parse --show-toplevel)
 
 DL_FOLDER=$CUR_GIT_ROOT/dl_third_party
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 
-pip3 install aqtinstall  # https://github.com/miurahr/aqtinstall
+pip3 install -r ${DIR}/for_pip/requirements.txt  # https://github.com/miurahr/aqtinstall
 #
 # NOTE: as of Nov 23, 2020, it is not clear whether 'win64_msvc2019_64' is the right ARCH
 # argument to pass to aqtinstall. We may need to try other options:
@@ -14,7 +15,7 @@ pip3 install aqtinstall  # https://github.com/miurahr/aqtinstall
 # Refer to: https://github.com/miurahr/aqtinstall#usage
 
 # https://github.com/miurahr/aqtinstall/issues/126 "Installing smaller subset of the libraries"
-python -m aqt install-qt windows desktop 5.15.0 win64_msvc2019_64 --outputdir $DL_FOLDER/Qt_desktop --archives \
+python -m aqt install --outputdir $DL_FOLDER/Qt_desktop 5.15.0 windows desktop win64_msvc2019_64 --archives \
         icu \
         qtbase \
         qtconnectivity \

--- a/tools/update_version_strings.sh
+++ b/tools/update_version_strings.sh
@@ -27,6 +27,5 @@ if [[ "$OSTYPE" == "darwin"* ]]; then
   gsed -i "/GIT_HASH_WHEN_BUILT/c ${NEW_HASHLINE}" "$GENFILE"         # 2. then operate in-place on genfile
 else
   # find matching lines and replace WHOLE line with new strings
-  sed "/BUILD_ON_DATE/c ${NEW_DATELINE}" "$STRINGSFILE" > "$GENFILE" # 1. create genfile
-  sed -i "/GIT_HASH_WHEN_BUILT/c ${NEW_HASHLINE}" "$GENFILE"         # 2. then operate in-place on genfile
+  sed -e "/BUILD_ON_DATE/c ${NEW_DATELINE}" "$STRINGSFILE" -e "/GIT_HASH_WHEN_BUILT/c ${NEW_HASHLINE}" > "$GENFILE" # 1. create genfile
 fi


### PR DESCRIPTION
- added .user files to gitignore, .user files are used by qt creator and we don't want those in the repo
- fixed an error in the readme for windows builds
- changed provision_win.sh to use the requirements.txt that linux uses, so they stay matched
- changed update_version_string.sh to execute both commands together instead of appending. The problem with -i (appending) is it creates a temp file somewhere and on windows if you call bash update_version_string.sh, the temp file is created in system32 which causes permissions errors. In general sed -i should be avoided because the file permissions don't always hold