### PR TITLE
Update cookiecutter link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ You must also read "Your first commit" (below) before continuing further:
 
 (Skip this section if you chose to click GitHub's "Use this template" button.)
 
-Get [cookiecutter](https://cookiecutter.readthedocs.io/).
+Get [cookiecutter](https://cookiecutter.readthedocs.io/en/latest/).
 
 Pull down our cookiecutter-ized branch using cookiecutter directly, like so:
 


### PR DESCRIPTION
The existing link, https://cookiecutter.readthedocs.io/, takes you
to an old version of the cookiecutter documentation, where you are
told, "You are not reading the most recent version of this
documentation. 2.0.2 is the latest version available." This appears
to be a bug in cookiecutter's documentation itself; even their own
latest documentation page:

https://cookiecutter.readthedocs.io/en/2.0.2/README.html

links to https://cookiecutter.readthedocs.io/, which in turn takes
you back to that same old page for version 1.7.2.