### PR TITLE
Get clang-format-10 directly from Ubuntu, not LLVM

### DIFF
--- a/tools/ci/get_llvm_clang-format.sh
+++ b/tools/ci/get_llvm_clang-format.sh
@@ -4,21 +4,6 @@ set -Eeuxo pipefail # https://vaneyckt.io/posts/safer_bash_scripts_with_set_euxo
 
 # When we end up here from the cookiecutterize job, we cannot rely on git
 #CUR_GIT_ROOT=$(git rev-parse --show-toplevel)
-## BEGIN: clang-format from LLVM
-wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key|sudo apt-key add -
-# Fingerprint: 6084 F3CF 814B 57C1 CF12 EFD5 15CF 4D18 AF4F 7421
-
-echo '' | sudo tee -a /etc/apt/sources.list
-
-if [[ $(lsb_release -rs) == "20.04" ]]; then
-  echo 'deb http://apt.llvm.org/focal/ llvm-toolchain-focal-10 main' | sudo tee -a /etc/apt/sources.list
-  echo 'deb-src http://apt.llvm.org/focal/ llvm-toolchain-focal-10 main' | sudo tee -a /etc/apt/sources.list
-else
-  echo 'deb http://apt.llvm.org/bionic/ llvm-toolchain-bionic-10 main' | sudo tee -a /etc/apt/sources.list
-  echo 'deb-src http://apt.llvm.org/bionic/ llvm-toolchain-bionic-10 main' | sudo tee -a /etc/apt/sources.list
-fi
 
 sudo apt-get update
 sudo apt-get --assume-yes install clang-format-10
-
-## END: clang-format from LLVM


### PR DESCRIPTION
tools/ci/provision.sh runs tools/ci/get_llvm_clang-format.sh, which
was adding a llvm.org repository to sources.list: the list of
places Ubuntu will look to find packages to install. This resulted
in a conflict where Ubuntu's apt program refuses to install
clang-format-10 when the command to do so in tools/ci/provision.sh
is run.

Simply not adding the llvm.org repository to sources.list seems to
resolve the issue, allowing clang-format-10 to be installed
successfully on Ubuntu 18.04, at least.

According to https://apt.llvm.org/, the packages llvm.org provides
via its sources are "extremely similar to the one shipping in
Debian & Ubuntu." It seems one key reason we might install packages
directly from llvm.org sources is to get access to later versions
of llvm tools than Ubuntu provides in its own repositories.
However, Ubuntu 18.04, at least, provides clang-format-10 directly
via apt, so there may be no need to add llvm.org repositories to
sources.list.