### PR TITLE
Install clang-format-10 before init_repo.sh run

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,12 @@ You must also read "Your first commit" (below) before continuing further:
 ### Your first commit:
 
 Once either the GitHub "Use this template" button or cookiecutter has completed
-its work, `cd` into the project directory and:
+its work, make sure you have `clang-format-10` installed:
+```
+sudo apt install clang-format-10
+```
+
+Then `cd` into the project directory and:
 
 - If you used cookiecutter, then run:
 ```


### PR DESCRIPTION
The cookiecutter/init_repo.sh script executes
tools/formatters/enforce_clang_format.sh, which executes
clang-format-10. However, in the existing README.md instructions,
clang-format-10 is not installed until after init_repo.sh is run
(specifically, when tools/ci/provision.sh is run), causing
init_repo.sh to fail if clang-format-10 is not already installed.

Here, we explicitly instruct the reader of README.md to install
clang-format-10 immediately before running init_repo.sh.