### PR TITLE
Add ./ before build_app.sh in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ After that, please proceed to "How to build" (below) before continuing further:
     - `export MYAPP_TEMPLATE_BUILD_ANDROID=1 # optional`
     - `export MYAPP_TEMPLATE_BUILD_APPIMAGE=1 # optional`
 
-4. In a terminal, run `build_app.sh`
+4. In a terminal, run `./build_app.sh`
 
 5. Assuming step (4) was successful, you can launch the app at
    `./build/src/app/app` (or on Windows: `start build/windeployfolder/app.exe`)

--- a/README.md
+++ b/README.md
@@ -68,7 +68,12 @@ You must also read "Your first commit" (below) before continuing further:
 ### Your first commit:
 
 Once either the GitHub "Use this template" button or cookiecutter has completed
-its work, `cd` into the project directory and:
+its work, make sure you have `clang-format-10` installed:
+```
+sudo apt install clang-format-10
+```
+
+Then `cd` into the project directory and:
 
 - If you used cookiecutter, then run:
 ```


### PR DESCRIPTION
For consistency with other run commands in README.md, we add ./
before build_app.sh only in the step for running that script.