### PR TITLE
reproduce bug qt6...metatypes.json: illegal value (windows nmake)

### DIFF
--- a/.github/workflows/json_bug_repro.yml
+++ b/.github/workflows/json_bug_repro.yml
@@ -1,0 +1,17 @@
+name: json_bug_repro
+
+on: [push]
+
+jobs:
+  build:
+
+    runs-on: windows-2019
+
+    steps:
+    - uses: actions/checkout@v1
+
+    - name: nmake_build
+      shell: cmd
+      run: |
+        call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvars64.bat"
+        "C:\Program Files\Git\bin\bash.exe" ./json_bug_repro/ci/win_ci.sh

--- a/json_bug_repro/CMakeLists.txt
+++ b/json_bug_repro/CMakeLists.txt
@@ -1,0 +1,28 @@
+cmake_minimum_required(VERSION 3.16)
+
+project(Reproducejsonbug VERSION 0.1 LANGUAGES CXX)
+
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+find_package(Qt6 REQUIRED COMPONENTS Quick Bluetooth)
+
+qt_standard_project_setup(REQUIRES 6.5)
+
+
+qt_add_executable(appReproducejsonbug
+    main.cpp
+)
+
+qt_add_qml_module(appReproducejsonbug
+    URI Reproducejsonbug
+    VERSION 1.0
+        QML_FILES  qml/Main.qml
+)
+
+set_target_properties(appReproducejsonbug PROPERTIES
+    WIN32_EXECUTABLE TRUE
+)
+
+target_link_libraries(appReproducejsonbug
+    PRIVATE Qt6::Quick
+)

--- a/json_bug_repro/ci/qtapps/ci.sh
+++ b/json_bug_repro/ci/qtapps/ci.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+
+set -Eeuxo pipefail # https://vaneyckt.io/posts/safer_bash_scripts_with_set_euxo_pipefail/
+IFS=$'\n\t'
+
+THISDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+
+source ${THISDIR}/utils.bash # will compute UTILS_WE_ARE_RUNNING_IN_CI
+
+if [[ -n ${UTILS_WE_ARE_RUNNING_IN_CI-} ]];
+# The '-' hyphen above tests without angering the 'set -u' about unbound variables
+then
+  echo "C.I. environment was detected."
+
+  # Try various ways to print OS version info.
+  # This lets us keep a record of this in our CI logs,
+  # in case the CI docker images change.
+  uname -a       || true
+  lsb_release -a || true
+  gcc --version  || true  # oddly, gcc often prints great OS information
+  cat /etc/issue || true
+
+  # What environment variables did the C.I. system set? Print them:
+  env
+
+  if [[ "$OSTYPE" != "cygwin" && "$OSTYPE" != "msys" ]]; then
+    ${THISDIR}/../verify_authors.sh
+
+    ${THISDIR}/linux_apt_get_qt_deps.sh
+    ${THISDIR}/get_qt_libs.sh
+  elif [[ "$OSTYPE" == "cygwin" || "$OSTYPE" == "msys" ]]; then
+    ${THISDIR}/provision_win.sh
+  fi
+
+else
+  echo "Assuming we are NOT in cloud C.I. environment."
+fi
+
+
+THIS_FILENAME=$(basename "$0")
+echo 'We assume this was run with '\''set -e'\'' (look at upper lines of this script).'
+echo 'Assuming so, then getting here means:'
+echo "${THIS_FILENAME} SUCCESS"

--- a/json_bug_repro/ci/qtapps/provision_win.sh
+++ b/json_bug_repro/ci/qtapps/provision_win.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+set -Eeuxo pipefail # https://vaneyckt.io/posts/safer_bash_scripts_with_set_euxo_pipefail/
+
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+source "${DIR}/rootdirhelper.bash"
+
+DL_FOLDER=$CUR_GUICODE_ROOT/dl_third_party
+if [[ -n ${MYAPP_TEMPLATE_DL_FOLDER_OVERRIDE-} ]]; then
+  DL_FOLDER=${MYAPP_TEMPLATE_DL_FOLDER_OVERRIDE}
+fi
+
+pip3 install -r ${DIR}/requirements.txt  # https://github.com/miurahr/aqtinstall
+
+python3 -m aqt install-qt --outputdir $DL_FOLDER/Qt_desktop \
+  windows desktop 6.5.3 win64_msvc2019_64 \
+  --modules \
+  qtconnectivity \
+  qtimageformats \
+  qt5compat

--- a/json_bug_repro/ci/qtapps/requirements.txt
+++ b/json_bug_repro/ci/qtapps/requirements.txt
@@ -1,0 +1,1 @@
+aqtinstall==3.1.12

--- a/json_bug_repro/ci/qtapps/rootdirhelper.bash
+++ b/json_bug_repro/ci/qtapps/rootdirhelper.bash
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+if [ "${BASH_SOURCE[0]}" -ef "$0" ]
+then
+    echo "Hey, you should source this script, not execute it!"
+    exit 1
+fi
+
+NESTED_GUI_ROOT="" # Populate this if you move the qt-qml-project beneath git root
+CUR_GIT_ROOT=$(git rev-parse --show-toplevel)
+
+export CUR_GUICODE_ROOT="${CUR_GIT_ROOT}/${NESTED_GUI_ROOT}/"
+
+DL_FOLDER=$CUR_GUICODE_ROOT/dl_third_party
+if [[ -n ${MYAPP_TEMPLATE_DL_FOLDER_OVERRIDE-} ]]; then
+  DL_FOLDER=${MYAPP_TEMPLATE_DL_FOLDER_OVERRIDE}
+fi

--- a/json_bug_repro/ci/qtapps/utils.bash
+++ b/json_bug_repro/ci/qtapps/utils.bash
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+if [ "${BASH_SOURCE[0]}" -ef "$0" ]
+then
+    echo "Hey, you should source this script, not execute it!"
+    exit 1
+fi
+
+if [[ -n ${TERM-} && ${TERM-} != "dumb" && ${TERM-} != "emacs" ]]; then
+  # https://stackoverflow.com/a/20983251/10278
+  u_red=`tput setaf 1`
+  u_green=`tput setaf 2`
+  u_resetcolor=`tput sgr0` # keep reset LAST. The above do change the output.
+else
+  u_red=''
+  u_green=''
+  u_resetcolor=''
+fi
+
+# https://web.archive.org/web/20191121235402/https://confluence.atlassian.com/bitbucket/variables-in-pipelines-794502608.html
+if [[ -n ${GITHUB_ACTIONS-} || -n ${BITBUCKET_REPO_OWNER-} || -n ${BITBUCKET_REPO_FULL_NAME-} ]];
+# The '-' hyphens above test without angering the 'set -u' about unbound variables
+then
+  export UTILS_WE_ARE_RUNNING_IN_CI=1
+  echo "Assuming C.I. environment."
+  echo "Found at least one of GITHUB_ACTIONS, BITBUCKET_REPO_OWNER, BITBUCKET_REPO_FULL_NAME in env."
+fi

--- a/json_bug_repro/ci/win_ci.sh
+++ b/json_bug_repro/ci/win_ci.sh
@@ -1,0 +1,61 @@
+#!/bin/bash
+
+set -Eeuo pipefail # https://vaneyckt.io/posts/safer_bash_scripts_with_set_euxo_pipefail/
+IFS=$'\n\t'
+
+THISDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+CUR_GIT_ROOT=$(git rev-parse --show-toplevel)
+
+if [[ "$OSTYPE" != "cygwin" && "$OSTYPE" != "msys" ]]; then
+  echo "This script is for use on Microsoft Windows"
+  exit 1
+fi
+
+if [[ -z ${VCToolsInstallDir-} ]]; then
+  echo "WHOOPS. vcvars64 (or vcvarsall) was not called yet."
+  echo "You MUST start a VISUAL STUDIO command prompt. (Then start git-bash from within it.)"
+  echo "Read the above and try again."
+  exit 1
+fi
+
+
+"${THISDIR}"/qtapps/ci.sh
+
+source "${THISDIR}"/qtapps/rootdirhelper.bash
+
+MSVCPATHFORBUILDING=$(cygpath -u "${VCToolsInstallDir}/bin/HOSTx64/x64")
+export PATH="${MSVCPATHFORBUILDING}:$PATH" # make sure MSVC link.exe is found (not bash/unix 'link' tool)
+
+WINDLPATH=$(cygpath -u $DL_FOLDER)
+
+# Variables used by CMakeLists
+export Qt6_DIR="${WINDLPATH}/Qt_desktop/6.5.3/msvc2019_64/lib/cmake/Qt6/"
+
+# Put qmake on the PATH:
+export PATH="${WINDLPATH}/Qt_desktop/6.5.3/msvc2019_64/bin:$PATH"
+
+
+
+mkdir -p cbuild
+pushd cbuild
+
+  cmake "-G" "NMake Makefiles" -DCMAKE_VERBOSE_MAKEFILE:BOOL=ON $THISDIR/..
+
+  # See: https://forum.qt.io/topic/146961/building-qt6-5-with-nmake-error
+  # Workaround for bug in Qt6CoreMacros.cmake:
+  #buggy_genfile=meta_types/qt6appreproducejsonbug_debug_metatypes.json
+  #if [ ! -s "$buggy_genfile" ]; then
+  #  echo "{}" >> "$buggy_genfile"
+  #fi
+
+  nmake
+
+
+popd # pushd cbuild
+
+
+
+THIS_FILENAME=$(basename "$0")
+echo 'We assume this was run with '\''set -e'\'' (look at upper lines of this script).'
+echo 'Assuming so, then getting here means:'
+echo "${THIS_FILENAME} SUCCESS"

--- a/json_bug_repro/main.cpp
+++ b/json_bug_repro/main.cpp
@@ -1,0 +1,18 @@
+#include <QGuiApplication>
+#include <QQmlApplicationEngine>
+#include <QQuickView>
+#include <QQmlContext>
+#include <QQmlEngine>
+
+#include <QObject>
+
+
+int main(int argc, char *argv[])
+{
+    QGuiApplication app(argc, argv);
+
+    QQmlApplicationEngine engine;
+    engine.loadFromModule("Reproducejsonbug", "Main");
+
+    app.exec();
+}

--- a/json_bug_repro/qml/Main.qml
+++ b/json_bug_repro/qml/Main.qml
@@ -1,0 +1,7 @@
+import QtQuick
+
+Window {
+    width: 1200
+    height: 600
+    visible: true
+}


### PR DESCRIPTION
Adding a very simple CMakeLists.txt, main.cpp, and Main.qml, along with some scripts so that this is compiled in a GitHub CI runner for win64_msvc2019_64 using Qt 6.5.3.

This reproduces the issue described at https://forum.qt.io/topic/146961/building-qt6-5-with-nmake-error

However, skip ahead to the very next PR in this repo (a PR that will also be marked as draft and then closed without merging it), and in the next PR (PR #121) you can see that updating from Qt 6.5.3 to Qt 6.7.3 eliminates the problem. 🎉

with nmake on win64_msvc2019_64 using Qt 6.5.3 (as in this PR), the error looks like:
```
[ 25%] Built target appReproducejsonbug_automoc_json_extraction
	"C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Tools\MSVC\14.29.30133\bin\HOSTx64\x64\nmake.exe"  -f CMakeFiles\appReproducejsonbug.dir\build.make /nologo -L                  CMakeFiles\appReproducejsonbug.dir\depend
[ 30%] Automatic QML type registration for target appReproducejsonbug
	call .qt\bin\qt_setup_tool_path.bat D:/a/qt-qml-project-template-with-ci/qt-qml-project-template-with-ci/dl_third_party/Qt_desktop/6.5.3/msvc2019_64/./bin/qmltyperegistrar.exe --generate-qmltypes=D:/a/qt-qml-project-template-with-ci/qt-qml-project-template-with-ci/cbuild/Reproducejsonbug/appReproducejsonbug.qmltypes --import-name=Reproducejsonbug --major-version=1 --minor-version=0 @D:/a/qt-qml-project-template-with-ci/qt-qml-project-template-with-ci/cbuild/qmltypes/appReproducejsonbug_foreign_types.txt -o D:/a/qt-qml-project-template-with-ci/qt-qml-project-template-with-ci/cbuild/appreproducejsonbug_qmltyperegistrations.cpp D:/a/qt-qml-project-template-with-ci/qt-qml-project-template-with-ci/cbuild/meta_types/qt6appreproducejsonbug_debug_metatypes.json
Error 5 while parsing D:/a/qt-qml-project-template-with-ci/qt-qml-project-template-with-ci/cbuild/meta_types/qt6appreproducejsonbug_debug_metatypes.json: illegal value
NMAKE : fatal error U1077: 'call' : return code '0x1'
Stop.

```

As shown in the log: https://github.com/219-design/qt-qml-project-template-with-ci/actions/runs/14743379442

(However, the log will expire after a few days. You'd want to clone or fork this repro if you have any desire to reproduce this again.)