### PR TITLE
bug-fix (by using Qt 6.7.3) qt6...metatypes.json: illegal value (windows nmake)

### DIFF
--- a/json_bug_repro/ci/qtapps/provision_win.sh
+++ b/json_bug_repro/ci/qtapps/provision_win.sh
@@ -13,7 +13,7 @@ fi
 pip3 install -r ${DIR}/requirements.txt  # https://github.com/miurahr/aqtinstall
 
 python3 -m aqt install-qt --outputdir $DL_FOLDER/Qt_desktop \
-  windows desktop 6.5.3 win64_msvc2019_64 \
+  windows desktop 6.7.3 win64_msvc2019_64 \
   --modules \
   qtconnectivity \
   qtimageformats \

--- a/json_bug_repro/ci/win_ci.sh
+++ b/json_bug_repro/ci/win_ci.sh
@@ -29,10 +29,10 @@ export PATH="${MSVCPATHFORBUILDING}:$PATH" # make sure MSVC link.exe is found (n
 WINDLPATH=$(cygpath -u $DL_FOLDER)
 
 # Variables used by CMakeLists
-export Qt6_DIR="${WINDLPATH}/Qt_desktop/6.5.3/msvc2019_64/lib/cmake/Qt6/"
+export Qt6_DIR="${WINDLPATH}/Qt_desktop/6.7.3/msvc2019_64/lib/cmake/Qt6/"
 
 # Put qmake on the PATH:
-export PATH="${WINDLPATH}/Qt_desktop/6.5.3/msvc2019_64/bin:$PATH"
+export PATH="${WINDLPATH}/Qt_desktop/6.7.3/msvc2019_64/bin:$PATH"
 
 
 


### PR DESCRIPTION
This change shows that the "metatypes.json: illegal value" build error can be avoided by upgrading from Qt 6.5.3 to 6.7.3.

See PR #120 for a bit more discussion (and an alternative workaround).

Whereas the build for the prior PR fails, on this PR the log arrives at completion:
```
qrc_appReproducejsonbug_raw_qml_0.cpp
[ 95%] Linking CXX executable appReproducejsonbug.exe
	"C:\Program Files\CMake\bin\cmake.exe" -E vs_link_exe --msvc-ver=1929 --intdir=CMakeFiles\appReproducejsonbug.dir --rc=C:\PROGRA~2\WI3CF2~1\10\bin\100226~1.0\x64\rc.exe --mt=C:\PROGRA~2\WI3CF2~1\10\bin\100226~1.0\x64\mt.exe --manifests -- C:\PROGRA~2\MICROS~2\2019\ENTERP~1\VC\Tools\MSVC\1429~1.301\bin\Hostx64\x64\link.exe  @CMakeFiles\appReproducejsonbug.dir\objects1.rsp @C:\Users\RUNNER~1\AppData\Local\Temp\nmEC0F.tmp
[100%] Built target appReproducejsonbug
	"C:\Program Files\CMake\bin\cmake.exe" -E cmake_progress_start D:\a\qt-qml-project-template-with-ci\qt-qml-project-template-with-ci\cbuild\CMakeFiles 0
/d/a/qt-qml-project-template-with-ci/qt-qml-project-template-with-ci
We assume this was run with 'set -e' (look at upper lines of this script).
Assuming so, then getting here means:
win_ci.sh SUCCESS
```

Log can be found here until it expires: https://github.com/219-design/qt-qml-project-template-with-ci/actions/runs/14743492206
