### PR TITLE
ci: enable compile_commands.json and also sort it with jq. benefit:

### DIFF
--- a/build_cmake_app.sh
+++ b/build_cmake_app.sh
@@ -97,7 +97,11 @@ fi
 mkdir -p cbuild
 pushd cbuild
 
-  cmake ${MYAPP_EXTRA_CONF[@]} -DCMAKE_VERBOSE_MAKEFILE:BOOL=ON $DIR
+  cmake \
+    ${MYAPP_EXTRA_CONF[@]} \
+    -DCMAKE_VERBOSE_MAKEFILE:BOOL=ON \
+    -DCMAKE_EXPORT_COMPILE_COMMANDS:BOOL=ON \
+    $DIR
 
   ${makecmd} ${MYAPP_JOBS}
 
@@ -108,6 +112,17 @@ pushd cbuild
   #if [[ "$OSTYPE" == "cygwin" || "$OSTYPE" == "msys" ]]; then
   #  ${makecmd} debug
   #fi
+
+  # Works on Linux, Mac, and Windows as long as you have `jq`:
+  "${CUR_GUICODE_ROOT}"/tools/formatters/write_sorted_json.sh \
+    compile_commands.json \
+    sorted_compile_commands.json
+
+  if [[ -n ${UTILS_WE_ARE_RUNNING_IN_CI-} ]]; then
+    # In CI, let's dump this info into the log. (Admittedly, it is on-the-whole
+    # redundant with prior cmake commands in the log, but at least now it is sorted)
+    cat sorted_compile_commands.json
+  fi
 
 popd # pushd cbuild
 

--- a/tools/formatters/normalize.jq
+++ b/tools/formatters/normalize.jq
@@ -1,0 +1,17 @@
+# https://stackoverflow.com/questions/38257725/how-can-i-completely-sort-arbitrary-json-using-jq
+
+# This jq function/snippet is used by our bash script write_sorted_json.sh
+
+# Apply f to composite entities recursively using keys[], and to atoms
+def sorted_walk(f):
+  . as $in
+  | if type == "object" then
+      reduce keys[] as $key
+        ( {}; . + { ($key):  ($in[$key] | sorted_walk(f)) } ) | f
+  elif type == "array" then map( sorted_walk(f) ) | f
+  else f
+  end;
+
+def normalize: sorted_walk(if type == "array" then sort else . end);
+
+normalize

--- a/tools/formatters/write_sorted_json.sh
+++ b/tools/formatters/write_sorted_json.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+set -Eeuxo pipefail # https://vaneyckt.io/posts/safer_bash_scripts_with_set_euxo_pipefail/
+IFS=$'\n\t'
+
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+
+# shellcheck disable=SC1091
+source "${DIR}/../ci/utils.bash" # for terminal colorization
+
+echo "First argument to script is SRC file"
+INPUT_FILE=$1
+shift 1
+
+echo "Next argument to script is DEST (output) file"
+OUT_FILE=$1
+shift 1
+
+jq -S -f "${DIR}"/normalize.jq "$INPUT_FILE" > "$OUT_FILE"
+
+THIS_FILENAME=$(basename "$0")
+echo 'We assume this was run with '\''set -e'\'' (look at upper lines of this script).'
+echo 'Assuming so, then getting here means:'
+echo "${u_green}${THIS_FILENAME} '$INPUT_FILE' '$OUT_FILE' SUCCESS${u_resetcolor}"


### PR DESCRIPTION
this gives us a way to "diff a build" against a prior build after (for example) making changes to CMake settings or changing compiler version, etc.