### PR TITLE
ci: on unix/unices, enable {ASan, UBSan, leak-check} in Debug build

### DIFF
--- a/cmake_include/unix_settings.cmake
+++ b/cmake_include/unix_settings.cmake
@@ -40,6 +40,45 @@ if(UNIX)
         "-Wunused-but-set-parameter"
       )
     endif() # if (NOT wants_clang)
+
+    set(MYAPP_UNIX_SANITIZER_FLAGS
+        " -fsanitize=address,undefined,leak \
+          -fno-sanitize-recover \
+          -fno-omit-frame-pointer \
+        "
+    )
+
+    string(
+      APPEND
+      CMAKE_C_FLAGS_DEBUG
+      "${MYAPP_UNIX_SANITIZER_FLAGS}"
+    )
+    string(
+      APPEND
+      CMAKE_CXX_FLAGS_DEBUG
+      "${MYAPP_UNIX_SANITIZER_FLAGS}"
+    )
+    string(
+      APPEND
+      CMAKE_EXE_LINKER_FLAGS_DEBUG
+      "${MYAPP_UNIX_SANITIZER_FLAGS}"
+    )
+    string(
+      APPEND
+      CMAKE_SHARED_LINKER_FLAGS_DEBUG
+      "${MYAPP_UNIX_SANITIZER_FLAGS}"
+    )
+    string(
+      APPEND
+      CMAKE_STATIC_LINKER_FLAGS_DEBUG
+      "${MYAPP_UNIX_SANITIZER_FLAGS}"
+    )
+    string(
+      APPEND
+      CMAKE_MODULE_LINKER_FLAGS_DEBUG
+      "${MYAPP_UNIX_SANITIZER_FLAGS}"
+    )
+
   endif() # if (NOT ANDROID)
 
   # some compiler warnings inspired by:

--- a/src/app/main.cc
+++ b/src/app/main.cc
@@ -18,6 +18,10 @@
 #include "src/util/am_i_inside_debugger.h"
 #include "util-assert.h"
 
+#if defined( __linux__ )
+#    include "src/minutil/debug_sanitizer_config.cc" // <-- not a header! meant as inline code here.
+#endif // #if defined( __linux__ )
+
 int main( int argc, char* argv[] )
 {
     project::SetAppVersionStringForLogging( project::GIT_HASH_WHEN_BUILT );

--- a/src/libtests/CMakeLists.txt
+++ b/src/libtests/CMakeLists.txt
@@ -17,6 +17,11 @@ target_include_directories(
     ${PROJECT_SOURCE_DIR}/third_party/googletest-release-1.11.0/googletest/include
 )
 
+target_include_directories(
+  testmain
+  PRIVATE ${PROJECT_SOURCE_DIR}
+)
+
 target_link_libraries(
   testmain
   PRIVATE Qt::Core

--- a/src/libtests/libtestmain.pro
+++ b/src/libtests/libtestmain.pro
@@ -16,6 +16,8 @@ TARGET  = testmain
 SOURCES += \
     test_main.cc
 
+INCLUDEPATH += $${top_srcdir}
+
 !include(../../third_party/googletest-release-1.11.0/googlemock/googlemock.pri) { error() }
 !include(../../third_party/googletest-release-1.11.0/googletest/googletest.pri) { error() }
 

--- a/src/libtests/qt_test_main.cc
+++ b/src/libtests/qt_test_main.cc
@@ -11,6 +11,10 @@
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
 
+#if defined( __linux__ )
+#    include "src/minutil/debug_sanitizer_config.cc" // <-- not a header! meant as inline code here.
+#endif // #if defined( __linux__ )
+
 // This test runner implements the common setup for all googletest-based unit
 // tests which require access to a QCoreApplication instance. (Note: _not_ all
 // Qt-based code needs a QCoreApplication during its unit tests. Many tests of

--- a/src/libtests/test_main.cc
+++ b/src/libtests/test_main.cc
@@ -1,6 +1,10 @@
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
 
+#if defined( __linux__ )
+#    include "src/minutil/debug_sanitizer_config.cc" // <-- not a header! meant as inline code here.
+#endif // #if defined( __linux__ )
+
 int main( int argc, char* argv[] )
 {
     testing::InitGoogleTest( &argc, argv );

--- a/src/minutil/debug_sanitizer_config.cc
+++ b/src/minutil/debug_sanitizer_config.cc
@@ -1,0 +1,36 @@
+// This file is used to configure ASan, and also to suppress LSan leak reports
+// from third-party code that we cannot do anything about.
+
+// to quiet this: -Werror=missing-declarations ("no previous declaration for...")
+extern "C" const char* __lsan_default_suppressions();
+extern "C" const char* __asan_default_options();
+extern "C" const char* __ubsan_default_options();
+
+extern "C" const char* __lsan_default_suppressions()
+{
+    // See: https://github.com/google/sanitizers/issues/1628#issuecomment-1457253550
+
+    // Please make sure the code below declares a single string which contains
+    // LSan suppressions delimited by newlines.
+    return "leak:libfontconfig.so\n"
+           "leak:libfontconfig.so\n"; // intentional duplicate so we have 2, to show format
+}
+
+extern "C" const char* __asan_default_options()
+{
+    // Turn on static init order fiasco detection for ASan.
+    return "check_initialization_order=true:"
+           "strict_init_order=true:"
+           "detect_stack_use_after_return=1:"
+           "print_stacktrace=1";
+
+    // Options can also be passed at launch via env var:
+    //
+    // ASAN_OPTIONS=check_initialization_order=true:strict_init_order=true ./app
+}
+
+extern "C" const char* __ubsan_default_options()
+{
+    return "print_stacktrace=1:"
+           "print_stacktrace=1:"; // intentional duplicate so we have 2, to show format
+}

--- a/sw_arch_doc/excludes.txt
+++ b/sw_arch_doc/excludes.txt
@@ -22,3 +22,4 @@ ios_log_redirect
 am_i_inside_debugger
 navigation_test
 resources
+debug_sanitizer_config

--- a/tools/auto_test/run_cpp_auto_tests.sh
+++ b/tools/auto_test/run_cpp_auto_tests.sh
@@ -15,6 +15,18 @@ source "${THISDIR}/../ci/rootdirhelper.bash"
 
 source "${CUR_GUICODE_ROOT}/tools/ci/utils.bash" # for terminal colorization
 
+# Note that we also "bake in" some sanitization options at compile-time
+# through the use of our file: debug_sanitizer_config.cc
+#   ... feel free to mix and match based on per-project needs.
+export ASAN_OPTIONS="check_initialization_order=true:strict_init_order=true"
+export ASAN_OPTIONS="${ASAN_OPTIONS}:detect_stack_use_after_return=1"
+
+export UBSAN_OPTIONS="print_stacktrace=1"
+
+# On a ROS2 project, you will likely need:
+#  export ASAN_OPTIONS="${ASAN_OPTIONS}:new_delete_type_mismatch=0"
+#  ^^ Until this is fixed: https://github.com/ros2/rclcpp/issues/2220
+
 run_a_test() {
   while read filenames; do
     for fl in "$filenames"; do

--- a/tools/gui_test/launch_gui_for_display.sh
+++ b/tools/gui_test/launch_gui_for_display.sh
@@ -32,9 +32,14 @@ rm -f gui_test.log # in C.I. there should never be a leftover file. but perhaps 
 if [[ -n ${BITBUCKET_REPO_OWNER-} ]]; then
   ${APP_TO_LAUNCH} -g 2>&1 | tee gui_test.log
 elif [[ "$OSTYPE" != "darwin"* ]]; then
+    # leaksan and gdb "compete" for ptrace, so when we want gdb we have
+    # to disable leaksan: ASAN_OPTIONS=detect_leaks=0
+
     # "run, bt, run" is a workaround for a gdb behavior change between gdb 8 and gdb 9
     # for more info, see: https://sourceware.org/bugzilla/show_bug.cgi?id=27125
-    gdb -n -batch -return-child-result -ex "set args -g -v" -ex "run" -ex "bt" -ex "run" ${APP_TO_LAUNCH} 2>&1 | tee gui_test.log
+    ASAN_OPTIONS=detect_leaks=0 gdb -n -batch -return-child-result \
+        -ex "set args -g -v" -ex "run" -ex "bt" -ex "run" \
+        ${APP_TO_LAUNCH} 2>&1 | tee gui_test.log
 else
   build/src/app/app.app/Contents/MacOS/app -g 2>&1 | tee gui_test.log
 fi


### PR DESCRIPTION
This PR shows how to add {ASan, UBSan, leak-check} in a CMake build.

Several "learnings" are captured:
  - How your app code can "bake in" various ASan settings at compile-time.
  - How to make UBSan include a stacktrace.
  - Using `ASAN_OPTIONS` and `UBSAN_OPTIONS` environment variables when running tests (or your app).
  - Suppressing leak detection to run in `gdb` (`gdb` usage and leak-checks are mutually incompatible).
  - Suppressing LSan leak reports about third-party code (here: `libfontconfig.so`) that we cannot fix.

Further reading:
  - https://clang.llvm.org/docs/AddressSanitizer.html
  - https://clang.llvm.org/docs/UndefinedBehaviorSanitizer.html
  - https://blog.trailofbits.com/2024/05/16/understanding-addresssanitizer-better-memory-safety-for-your-code/
  - https://developers.redhat.com/blog/2014/10/16/gcc-undefined-behavior-sanitizer-ubsan
    
Intentional "Bad Code" To Insert For Testing That Sanitizers Are Running:

```
    int i = 23;
    i <<= 32;
    (void) i;

    int ii = INT_MIN;
    int j = -ii;
    (void) j;

    std::vector<bool> bla;
    bla.push_back( false );
    // just using a "barely wrong" index isn't always enough. use a flagrant one:
    fprintf( stderr, "%d\n", static_cast<int>( bla[ 64 ] ) );

    std::unique_ptr<int> test = std::make_unique<int>( 1 );
    auto newtest = std::move( test );
    fprintf( stderr, "%d\n", *test );

```
    